### PR TITLE
add_items spell wrong in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ fn main() -> Result<(), TopKErr> {
     let data = vec![1, 2, 3, 7, 8, 9, 0];
     let mut qs = top_k::quick_select::QuickSelect::new(2);
     
-    qs.add_times(data);
+    qs.add_items(data);
     let res = qs.top_k()?;
     
     if res != vec![8, 9] && res != vec![9, 8] {

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ fn main() -> Result<(), TopKErr> {
     let data = vec![1, 2, 3, 7, 8, 9, 0];
     let mut qs = top_k::quick_select::QuickSelect::new(2);
     
-    qs.add_tiems(data);
+    qs.add_times(data);
     let res = qs.top_k()?;
     
     if res != vec![8, 9] && res != vec![9, 8] {


### PR DESCRIPTION
Hello, I found out that you misspelled `add_items` in the example section.
![image](https://user-images.githubusercontent.com/45072996/125648483-be50064e-cfcc-4c0c-b45b-0b3067417313.png)
which will casing compile error.
![image](https://user-images.githubusercontent.com/45072996/125648747-719215da-906d-44a1-b9b3-1f8653b53b4a.png)
